### PR TITLE
[build] Use package.trafficmanager instead of sonicstorage.blob

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ DSC_FILE = linux_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION).dsc
 DEBIAN_FILE = linux_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION).debian.tar.xz
 ORIG_FILE = linux_$(KERNEL_VERSION).orig.tar.xz
 BUILD_DIR=linux-$(KERNEL_VERSION)
-SOURCE_FILE_BASE_URL="https://sonicstorage.blob.core.windows.net/debian-security/pool/updates/main/l/linux"
+OURCE_FILE_BASE_URL="https://packages.trafficmanager.net/public/debian-security/pool/updates/main/l/linux"
 
 DSC_FILE_URL = "$(SOURCE_FILE_BASE_URL)/$(DSC_FILE)"
 DEBIAN_FILE_URL = "$(SOURCE_FILE_BASE_URL)/$(DEBIAN_FILE)"


### PR DESCRIPTION
Fix build error