### PR TITLE
Security: Disable CONFIG_CRYPTO_USER_API_AEAD for CVE-2026-31431

### DIFF
--- a/patch/kconfig-exclusions
+++ b/patch/kconfig-exclusions
@@ -4,6 +4,7 @@ CONFIG_STRICT_DEVMEM
 # Unset classid and priority network cgroups due to conflict between cgroups v1 and v2
 CONFIG_CGROUP_NET_CLASSID
 CONFIG_NET_CLS_CGROUP
+CONFIG_CRYPTO_USER_API_AEAD
 CONFIG_NETFILTER_XT_MATCH_CGROUP
 CONFIG_CGROUP_NET_PRIO
 ###-> mellanox_common-start


### PR DESCRIPTION
This patch disables the AEAD crypto API to mitigate the 'Copy Fail' vulnerability (CVE-2026-31431) in Linux kernel's algif_aead module.

The vulnerability allows local privilege escalation and container escape due to a race condition in the algif_aead encryption handling.

Modification in patch/kconfig-exclusions adds CONFIG_CRYPTO_USER_API_AEAD to the [common] exclusion list, ensuring it is not compiled into the kernel.

References:
- https://copy.fail/
- https://security-tracker.debian.org/tracker/CVE-2026-31431
