### PR TITLE
[202311.0] Security: Disable CONFIG_CRYPTO_USER_API_AEAD for CVE-2026-31431

### DIFF
--- a/patch/kconfig-exclusions
+++ b/patch/kconfig-exclusions
@@ -6,6 +6,8 @@ CONFIG_CGROUP_NET_CLASSID
 CONFIG_NET_CLS_CGROUP
 CONFIG_NETFILTER_XT_MATCH_CGROUP
 CONFIG_CGROUP_NET_PRIO
+# Disable AEAD crypto API to mitigate CVE-2026-31431 (copy.fail) in algif_aead
+CONFIG_CRYPTO_USER_API_AEAD
 ###-> mellanox_common-start
 ###-> mellanox_common-end
 


### PR DESCRIPTION
Backport of #12 to the 202311.0 branch.

Disables the AEAD crypto API to mitigate the 'Copy Fail' vulnerability (CVE-2026-31431) in the Linux kernel's algif_aead module.

Adds `CONFIG_CRYPTO_USER_API_AEAD` to `patch/kconfig-exclusions` `[common]` section so the option is not compiled into the kernel.

### References
- https://copy.fail/
- https://security-tracker.debian.org/tracker/CVE-2026-31431
- Original PR: edge-core/sonic-linux-kernel#12
