### PR TITLE
Security: Backport ESP and RxRPC fixes for CVE-2026-43284 and CVE-2026-43500 (Dirty Frag)

### DIFF
--- a/patch/CVE-2026-43284-esp-avoid-inplace-decrypt-shared-frags.patch
+++ b/patch/CVE-2026-43284-esp-avoid-inplace-decrypt-shared-frags.patch
@@ -1,0 +1,73 @@
+From: Gord Chen <gord_chen@edge-core.com>
+Date: Wed, 14 May 2026 15:07:00 +0000
+Subject: xfrm: esp: avoid in-place decrypt on shared skb frags (CVE-2026-43284)
+
+Backport of upstream commit f4c50a4034e6 to address CVE-2026-43284
+("Dirty Frag" ESP variant - local privilege escalation).
+
+splice() into a UDP socket via ip_append_page() attaches page-cache
+pages directly into skb frags without copying. ESP input then takes
+the no-COW fast path for uncloned skbs without a frag_list and
+decrypts in place over data that is not owned privately by the skb.
+This allows a local attacker to write into page-cache pages that back
+read-only files, enabling privilege escalation to root.
+
+Fix:
+1. Mark skbs built via ip_append_page() with SKBTX_SHARED_FRAG so
+   downstream consumers know the frags are externally owned.
+2. Make ESP input (esp4 and esp6) fall back to skb_cow_data() when
+   skb_has_shared_frag() is true.
+
+Tested on AS5835-54x running SONiC 202311.X (kernel 5.10.179):
+- Before patch: dirtyfrag exploit achieves root via ESP variant
+- After patch: ESP variant fails ("post-write verify failed")
+
+Upstream: f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4
+Fixes: cac2661c53f3 ("esp4: Avoid skb_cow_data whenever possible")
+Fixes: 03e2a30f6a27 ("esp6: Avoid skb_cow_data whenever possible")
+References: https://nvd.nist.gov/vuln/detail/CVE-2026-43284
+References: https://github.com/V4bel/dirtyfrag
+Signed-off-by: Gord Chen <gord_chen@edge-core.com>
+---
+ net/ipv4/esp4.c      | 3 ++-
+ net/ipv4/ip_output.c | 1 +
+ net/ipv6/esp6.c      | 3 ++-
+ 3 files changed, 5 insertions(+), 2 deletions(-)
+
+--- a/net/ipv4/esp4.c
++++ b/net/ipv4/esp4.c
+@@ -917,7 +917,8 @@ static int esp_input(struct xfrm_state *
+ 		if (!skb_is_nonlinear(skb)) {
+ 			nfrags = 1;
+ 
+ 			goto skip_cow;
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+ 			nfrags = skb_shinfo(skb)->nr_frags;
+ 			nfrags++;
+ 
+--- a/net/ipv4/ip_output.c
++++ b/net/ipv4/ip_output.c
+@@ -1444,6 +1444,7 @@ ssize_t	ip_append_page(struct sock *sk,
+ 		if (skb_append_pagefrags(skb, page, offset, len)) {
+ 			err = -EMSGSIZE;
+ 			goto error;
+ 		}
++		skb_shinfo(skb)->tx_flags |= SKBTX_SHARED_FRAG;
+ 
+ 		if (skb->ip_summed == CHECKSUM_NONE) {
+ 			__wsum csum;
+--- a/net/ipv6/esp6.c
++++ b/net/ipv6/esp6.c
+@@ -962,7 +962,8 @@ static int esp6_input(struct xfrm_state
+ 		if (!skb_is_nonlinear(skb)) {
+ 			nfrags = 1;
+ 
+ 			goto skip_cow;
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+ 			nfrags = skb_shinfo(skb)->nr_frags;
+ 			nfrags++;
+ 

--- a/patch/CVE-2026-43500-rxrpc-unshare-shared-frags.patch
+++ b/patch/CVE-2026-43500-rxrpc-unshare-shared-frags.patch
@@ -1,0 +1,51 @@
+From: Gord Chen <gord_chen@edge-core.com>
+Date: Wed, 14 May 2026 15:45:00 +0000
+Subject: rxrpc: Also unshare DATA packets when paged frags are present
+ (CVE-2026-43500)
+
+Backport of upstream commit aa54b1d27fe0 to address CVE-2026-43500
+("Dirty Frag" RxRPC variant - local privilege escalation).
+
+The DATA-packet handler in rxrpc_input_packet() uses skb_unshare()
+before calling into the security ops for in-place decryption.
+skb_unshare() only copies the skb when skb_cloned() is true.
+
+An skb that is not cloned but still carries externally-owned paged
+fragments (e.g. via splice() into a UDP socket through ip_append_page)
+falls through to the in-place decryption path, which writes into
+page-cache pages that back read-only files.
+
+Fix: when the skb has shared frags or a frag_list, linearize it via
+__pskb_pull_tail() to pull all paged data into the linear section
+before in-place decryption. This ensures crypto operates on private
+memory.
+
+Adapted for 5.10 where the vulnerable code is in net/rxrpc/input.c
+(upstream 6.5+ moved it to call_event.c/conn_event.c).
+
+Upstream: aa54b1d27fe0c2b78e664a34fd0fdf7cd1960d71
+Fixes: d0d5c0cd1e71 ("rxrpc: Use skb_unshare() rather than skb_cow_data()")
+References: https://nvd.nist.gov/vuln/detail/CVE-2026-43500
+References: https://github.com/V4bel/dirtyfrag
+Signed-off-by: Gord Chen <gord_chen@edge-core.com>
+---
+ net/rxrpc/input.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/net/rxrpc/input.c
++++ b/net/rxrpc/input.c
+@@ -1299,6 +1299,14 @@ void rxrpc_input_packet(struct rxrpc_loc
+ 				rxrpc_new_skb(skb, rxrpc_skb_unshared);
+ 				sp = rxrpc_skb(skb);
+ 			}
++
++			/* Also linearize if paged frags may be externally
++			 * owned (e.g. page-cache pages from splice).
++			 */
++			if (skb_has_frag_list(skb) || skb_has_shared_frag(skb)) {
++				if (!__pskb_pull_tail(skb, __skb_pagelen(skb)))
++					goto out;
++			}
+ 		}
+ 		break;
+ 

--- a/patch/series
+++ b/patch/series
@@ -296,12 +296,17 @@ armhf_secondary_boot_online.patch
 0002-patch-to-revert-the-platform-specific-reboot-commit.patch
 0007-Add-workaround-to-support-VXLAN-GPE-extension-BUM.patch
 
+# Security: CVE-2026-43284 (Dirty Frag ESP variant)
+CVE-2026-43284-esp-avoid-inplace-decrypt-shared-frags.patch
+CVE-2026-43500-rxrpc-unshare-shared-frags.patch
+
 #
 #
 ############################################################
 #
 # Internal patches will be added below (placeholder)
 # Do not add any public patch below this marker
+
 #
 ############################################################
 increase-interface-num-per-bridge-port.patch


### PR DESCRIPTION
## Summary

Backport of upstream commits to fix **both variants** of the Dirty Frag vulnerability:
- `f4c50a4034e6` — CVE-2026-43284 (ESP variant)
- `aa54b1d27fe0` — CVE-2026-43500 (RxRPC variant)

## Changes

### CVE-2026-43284 (ESP variant)
`patch/CVE-2026-43284-esp-avoid-inplace-decrypt-shared-frags.patch`:
- `net/ipv4/esp4.c`: add `skb_has_shared_frag()` check in fast-path
- `net/ipv6/esp6.c`: same
- `net/ipv4/ip_output.c`: set `SKBTX_SHARED_FRAG` in `ip_append_page()`

### CVE-2026-43500 (RxRPC variant)
`patch/CVE-2026-43500-rxrpc-unshare-shared-frags.patch`:
- `net/rxrpc/input.c`: linearize skb via `__pskb_pull_tail()` when paged frags are shared

### Series
- `patch/series`: add both patches

## Testing

Tested on AS5835-54x running SONiC 202311.X (kernel 5.10.179):
- **ESP variant**: blocked (`[su] post-write verify failed (target unchanged)`)
- **RxRPC variant**: blocked after linearization prevents page-cache write
- Combined result: `dirtyfrag: failed (rc=1)`

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-43284
- https://nvd.nist.gov/vuln/detail/CVE-2026-43500
- https://github.com/V4bel/dirtyfrag
- ESP upstream fix: https://git.kernel.org/stable/c/f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4
- RxRPC upstream fix: https://git.kernel.org/stable/c/aa54b1d27fe0c2b78e664a34fd0fdf7cd1960d71