### PR TITLE
Security: Backport skbuff shared-frag propagation fix for CVE-2026-46300 (Fragnesia)

### DIFF
--- a/patch/CVE-2026-46300-skbuff-propagate-shared-frag.patch
+++ b/patch/CVE-2026-46300-skbuff-propagate-shared-frag.patch
@@ -1,0 +1,53 @@
+From: Gord Chen <gord_chen@edge-core.com>
+Date: Thu, 15 May 2026 07:00:00 +0000
+Subject: net: skbuff: propagate shared-frag marker during coalescing and
+ pskb_copy (CVE-2026-46300)
+
+Backport of upstream patches by William Bowling and Hyunwoo Kim to
+address CVE-2026-46300 ("Fragnesia" - ESP-in-TCP page-cache write LPE).
+
+skb_try_coalesce() and __pskb_copy_fclone() transfer paged frag
+descriptors between skbs but do not propagate the shared-frag marker.
+This defeats the Dirty Frag ESP fix: ESP input sees
+skb_has_shared_frag() as false and decrypts in-place over page-cache
+backed frags that were originally marked as shared.
+
+Fix: propagate SKBTX_SHARED_FRAG in both functions when frag
+descriptors are transferred.
+
+Adapted for 5.10 which uses tx_flags/SKBTX_SHARED_FRAG instead of
+the 6.x flags/SKBFL_SHARED_FRAG field.
+
+Upstream:
+- https://lore.kernel.org/all/20260513041635.1289541-1-vakzz@zellic.io/
+- https://lore.kernel.org/all/agRfuVOeMI5pbHhY@v4bel/
+Fixes: cef401de7be8 ("net: fix possible wrong checksum generation")
+Fixes: f4c50a4034e6 ("xfrm: esp: avoid in-place decrypt on shared skb frags")
+References: https://nvd.nist.gov/vuln/detail/CVE-2026-46300
+References: https://github.com/v12-security/pocs/tree/main/fragnesia
+Signed-off-by: Gord Chen <gord_chen@edge-core.com>
+---
+ net/core/skbuff.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/net/core/skbuff.c
++++ b/net/core/skbuff.c
+@@ -1590,6 +1590,8 @@ struct sk_buff *__pskb_copy_fclone(struc
+ 			skb_frag_ref(skb, i);
+ 		}
+ 		skb_shinfo(n)->nr_frags = i;
++		skb_shinfo(n)->tx_flags |=
++			skb_shinfo(skb)->tx_flags & SKBTX_SHARED_FRAG;
+ 	}
+ 
+ 	if (skb_has_frag_list(skb)) {
+@@ -5236,6 +5238,9 @@ bool skb_try_coalesce(struct sk_buff *to
+ 	       from_shinfo->nr_frags * sizeof(skb_frag_t));
+ 	to_shinfo->nr_frags += from_shinfo->nr_frags;
+ 
++	if (from_shinfo->nr_frags)
++		to_shinfo->tx_flags |= from_shinfo->tx_flags & SKBTX_SHARED_FRAG;
++
+ 	if (!skb_cloned(from))
+ 		from_shinfo->nr_frags = 0;
+ 

--- a/patch/series
+++ b/patch/series
@@ -299,6 +299,7 @@ armhf_secondary_boot_online.patch
 # Security: CVE-2026-43284 (Dirty Frag ESP variant)
 CVE-2026-43284-esp-avoid-inplace-decrypt-shared-frags.patch
 CVE-2026-43500-rxrpc-unshare-shared-frags.patch
+CVE-2026-46300-skbuff-propagate-shared-frag.patch
 
 #
 #


### PR DESCRIPTION
## Summary

Backport of upstream patches to fix CVE-2026-46300 ("Fragnesia") which bypasses the Dirty Frag ESP fix.

## Root Cause

`skb_try_coalesce()` and `__pskb_copy_fclone()` transfer paged frag descriptors between skbs but do not propagate the `SKBTX_SHARED_FRAG` marker. This allows ESP input to see `skb_has_shared_frag()` as false and decrypt in-place over page-cache backed frags.

## Changes

`patch/CVE-2026-46300-skbuff-propagate-shared-frag.patch`:
- `net/core/skbuff.c` (`skb_try_coalesce`): propagate `SKBTX_SHARED_FRAG` when transferring frags
- `net/core/skbuff.c` (`__pskb_copy_fclone`): propagate `SKBTX_SHARED_FRAG` when copying frags

## Testing

Tested on AS5835-54x (kernel 5.10.179) with all three exploits:
- Dirty Frag ESP (CVE-2026-43284): **blocked**
- Dirty Frag RxRPC (CVE-2026-43500): **blocked**
- Fragnesia (CVE-2026-46300): **blocked** (EINVAL on SA setup + shared-frag propagation prevents bypass)

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-46300
- https://github.com/v12-security/pocs/tree/main/fragnesia
- https://lore.kernel.org/all/20260513041635.1289541-1-vakzz@zellic.io/
- https://lore.kernel.org/all/agRfuVOeMI5pbHhY@v4bel/