### PR TITLE
Security: Backport ptrace mm-NULL dumpable bypass fix for CVE-2026-46333

### DIFF
--- a/patch/CVE-2026-46333-ptrace-mm-null-dumpable-bypass.patch
+++ b/patch/CVE-2026-46333-ptrace-mm-null-dumpable-bypass.patch
@@ -1,0 +1,116 @@
+From 93d4ba49d18e3d7fb41a9927c2d0cca5e9dfefd6 Mon Sep 17 00:00:00 2001
+From: Linus Torvalds <torvalds@linux-foundation.org>
+Date: Wed, 13 May 2026 11:37:18 -0700
+Subject: ptrace: slightly saner 'get_dumpable()' logic
+
+commit 31e62c2ebbfdc3fe3dbdf5e02c92a9dc67087a3a upstream.
+
+The 'dumpability' of a task is fundamentally about the memory image of
+the task - the concept comes from whether it can core dump or not - and
+makes no sense when you don't have an associated mm.
+
+And almost all users do in fact use it only for the case where the task
+has a mm pointer.
+
+But we have one odd special case: ptrace_may_access() uses 'dumpable' to
+check various other things entirely independently of the MM (typically
+explicitly using flags like PTRACE_MODE_READ_FSCREDS).  Including for
+threads that no longer have a VM (and maybe never did, like most kernel
+threads).
+
+It's not what this flag was designed for, but it is what it is.
+
+The ptrace code does check that the uid/gid matches, so you do have to
+be uid-0 to see kernel thread details, but this means that the
+traditional "drop capabilities" model doesn't make any difference for
+this all.
+
+Make it all make a *bit* more sense by saying that if you don't have a
+MM pointer, we'll use a cached "last dumpability" flag if the thread
+ever had a MM (it will be zero for kernel threads since it is never
+set), and require a proper CAP_SYS_PTRACE capability to override.
+
+Reported-by: Qualys Security Advisory <qsa@qualys.com>
+Cc: Oleg Nesterov <oleg@redhat.com>
+Cc: Kees Cook <kees@kernel.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ include/linux/sched.h |  3 +++
+ kernel/exit.c         |  1 +
+ kernel/ptrace.c       | 22 ++++++++++++++++------
+ 3 files changed, 20 insertions(+), 6 deletions(-)
+
+diff --git a/include/linux/sched.h b/include/linux/sched.h
+index 3613c3f43b83e..540431e31681b 100644
+--- a/include/linux/sched.h
++++ b/include/linux/sched.h
+@@ -805,6 +805,9 @@ struct task_struct {
+ 	 */
+ 	unsigned			sched_remote_wakeup:1;
+ 
++	/* Save user-dumpable when mm goes away */
++	unsigned			user_dumpable:1;
++
+ 	/* Bit to tell LSMs we're in execve(): */
+ 	unsigned			in_execve:1;
+ 	unsigned			in_iowait:1;
+diff --git a/kernel/exit.c b/kernel/exit.c
+index cfdf2d275bba8..99ab6d7a09cee 100644
+--- a/kernel/exit.c
++++ b/kernel/exit.c
+@@ -528,6 +528,7 @@ static void exit_mm(void)
+ 	BUG_ON(mm != current->active_mm);
+ 	/* more a memory barrier than a real lock */
+ 	task_lock(current);
++	current->user_dumpable = (get_dumpable(mm) == SUID_DUMP_USER);
+ 	current->mm = NULL;
+ 	mmap_read_unlock(mm);
+ 	enter_lazy_tlb(mm, current);
+diff --git a/kernel/ptrace.c b/kernel/ptrace.c
+index aab480e24bd60..fb21c2bf55c37 100644
+--- a/kernel/ptrace.c
++++ b/kernel/ptrace.c
+@@ -287,11 +287,24 @@ static bool ptrace_has_cap(struct user_namespace *ns, unsigned int mode)
+ 	return ns_capable(ns, CAP_SYS_PTRACE);
+ }
+ 
++static bool task_still_dumpable(struct task_struct *task, unsigned int mode)
++{
++	struct mm_struct *mm = task->mm;
++	if (mm) {
++		if (get_dumpable(mm) == SUID_DUMP_USER)
++			return true;
++		return ptrace_has_cap(mm->user_ns, mode);
++	}
++
++	if (task->user_dumpable)
++		return true;
++	return ptrace_has_cap(&init_user_ns, mode);
++}
++
+ /* Returns 0 on success, -errno on denial. */
+ static int __ptrace_may_access(struct task_struct *task, unsigned int mode)
+ {
+ 	const struct cred *cred = current_cred(), *tcred;
+-	struct mm_struct *mm;
+ 	kuid_t caller_uid;
+ 	kgid_t caller_gid;
+ 
+@@ -352,11 +365,8 @@ ok:
+ 	 * Pairs with a write barrier in commit_creds().
+ 	 */
+ 	smp_rmb();
+-	mm = task->mm;
+-	if (mm &&
+-	    ((get_dumpable(mm) != SUID_DUMP_USER) &&
+-	     !ptrace_has_cap(mm->user_ns, mode)))
+-	    return -EPERM;
++	if (!task_still_dumpable(task, mode))
++		return -EPERM;
+ 
+ 	return security_ptrace_access_check(task, mode);
+ }
+-- 
+cgit 1.3-korg
+

--- a/patch/series
+++ b/patch/series
@@ -300,6 +300,7 @@ armhf_secondary_boot_online.patch
 CVE-2026-43284-esp-avoid-inplace-decrypt-shared-frags.patch
 CVE-2026-43500-rxrpc-unshare-shared-frags.patch
 CVE-2026-46300-skbuff-propagate-shared-frag.patch
+CVE-2026-46333-ptrace-mm-null-dumpable-bypass.patch
 
 #
 #


### PR DESCRIPTION
## Summary

Backport of upstream stable commit `93d4ba49d18e` to fix CVE-2026-46333 (ptrace mm-NULL bypass / ssh-keysign-pwn).

## Root Cause

`__ptrace_may_access()` skips the dumpable check when `task->mm == NULL`. During `do_exit()`, `exit_mm()` runs before `exit_files()`, allowing `pidfd_getfd(2)` to steal FDs from exiting setuid processes.

## Impact

- SSH host private keys stolen via ssh-keysign
- `/etc/shadow` readable via chage
- Deterministic exploit (100-2000 spawns)

## Changes

`patch/CVE-2026-46333-ptrace-mm-null-dumpable-bypass.patch`:
- `include/linux/sched.h`: add `user_dumpable` bitfield to `task_struct`
- `kernel/exit.c`: cache dumpability in `exit_mm()`
- `kernel/ptrace.c`: add `task_still_dumpable()`, use it in `__ptrace_may_access()`

## Build Note

⚠️ This patch modifies `task_struct` layout. Requires **full image rebuild** (not vmlinuz-only replacement).

## Testing

Reproduced on AS5835-54x (5.10.179): `sshkeysign_pwn` stole SSH host RSA private key in 5412 tries on unpatched kernel.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-46333
- https://github.com/0xdeadbeefnetwork/ssh-keysign-pwn
- https://security-tracker.debian.org/tracker/CVE-2026-46333
- Upstream: https://git.kernel.org/stable/c/93d4ba49d18e3d7fb41a9927c2d0cca5e9dfefd6